### PR TITLE
Started work on number normalisation

### DIFF
--- a/Source/DTSHashedContactsProvider.m
+++ b/Source/DTSHashedContactsProvider.m
@@ -87,6 +87,25 @@ typedef enum _DTSFieldToReturn {
 	return [[number componentsSeparatedByCharactersInSet:numbers] componentsJoinedByString:@""];
 }
 
+-(NSString*)cleanEmail:(NSString*)email
+{
+    // This cleans email+additional@provider.com to be email@provider.com
+    // which is another problematic scenario..
+    
+    NSRange plusRange = [email rangeOfString:@"+"];
+    if(plusRange.length > 0)
+    {
+        // found
+        NSRange atRange = [email rangeOfString:@"@"];
+        
+        NSString * start    = [email substringToIndex:plusRange.location];
+        NSString * rest     = [email substringFromIndex:atRange.location];
+        email = [start stringByAppendingString:rest];
+    }
+    
+    return email;
+}
+
 -(void)getTokens {
     //Retrieve entries on background thread so that we don't block the main one
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{    
@@ -114,7 +133,9 @@ typedef enum _DTSFieldToReturn {
             for( int j = 0; j < numberOfEntries; ++j ) {
                 NSString* email = (__bridge NSString *)CFArrayGetValueAtIndex(entries, j);
                 
-                if(self.contactFieldToReturn == DTSPhoneNumberField) {
+                if(self.contactFieldToReturn == DTSEmailField) {
+                    email = [self cleanEmail:email];
+                } else if(self.contactFieldToReturn == DTSPhoneNumberField) {
                     email = [self cleanNumber:email];
                 }
                 

--- a/Source/DTSHashedContactsProvider.m
+++ b/Source/DTSHashedContactsProvider.m
@@ -81,6 +81,12 @@ typedef enum _DTSFieldToReturn {
     }
 }
 
+-(NSString*)cleanNumber:(NSString*)number
+{	
+    NSCharacterSet *numbers = [[NSCharacterSet characterSetWithCharactersInString:@"+0123456789"] invertedSet];
+	return [[number componentsSeparatedByCharactersInSet:numbers] componentsJoinedByString:@""];
+}
+
 -(void)getTokens {
     //Retrieve entries on background thread so that we don't block the main one
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{    
@@ -107,6 +113,11 @@ typedef enum _DTSFieldToReturn {
             CFArrayRef entries = ABMultiValueCopyArrayOfAllValues(contactRef);
             for( int j = 0; j < numberOfEntries; ++j ) {
                 NSString* email = (__bridge NSString *)CFArrayGetValueAtIndex(entries, j);
+                
+                if(self.contactFieldToReturn == DTSPhoneNumberField) {
+                    email = [self cleanNumber:email];
+                }
+                
                 NSString* hashed = [self tokenForString:email];
                 [tokens addObject:hashed];
             };


### PR DESCRIPTION
Problem being, you need to know the source users phone book 'country' in order to properly normalise numbers, this first patch will clean out any space, bracket, dashes from numbers.

Future update will require knowing the users 'phone book country' in order to properly normalise numbers.

e.g.

User in SF with number "555-1212" in phone book is the same as a UK user with "+1 (415) 555-1212" in theirs. The current code does't account for that, so will miss users who know each other.
